### PR TITLE
Update macaca-reporter.js

### DIFF
--- a/lib/macaca-reporter.js
+++ b/lib/macaca-reporter.js
@@ -112,7 +112,7 @@ function MacacaReporter(runner, options) {
 
   const handleTestEnd = (isEnd) => {
     const obj = getSuiteData(isEnd);
-    obj.stats.duration = obj.suites._totalTime || 0;
+    obj.stats.duration = (new Date(obj.stats.end).getTime() - new Date(obj.stats.start).getTime()) || 0;
     this.output = obj;
 
     if (typeof window === 'object' &&


### PR DESCRIPTION
多线程执行 js 文件的情况下，持续时间=所有用例之和，该行为是错的。应该=结束时间减去开始时间